### PR TITLE
add last energy reading to attributes

### DIFF
--- a/custom_components/dynamic_energy_cost/energy_based_sensors.py
+++ b/custom_components/dynamic_energy_cost/energy_based_sensors.py
@@ -101,6 +101,7 @@ class BaseEnergyCostSensor(RestoreEntity, SensorEntity):
         """Return the state attributes of the device."""
         attrs = super().extra_state_attributes or {}  # Ensure it's a dict
         attrs['cumulative_energy_kwh'] = self._cumulative_energy_kwh
+        attrs['last_energy_reading'] = self._last_energy_reading
         attrs['average_energy_cost'] = self._state / self._cumulative_energy_kwh if self._cumulative_energy_kwh else 0
         return attrs
     
@@ -111,7 +112,7 @@ class BaseEnergyCostSensor(RestoreEntity, SensorEntity):
         last_state = await self.async_get_last_state()
         if last_state and last_state.state not in ['unknown', 'unavailable', None]:
             self._state = float(last_state.state)
-            self._last_energy_reading = float(last_state.attributes.get('last_energy'))
+            self._last_energy_reading = float(last_state.attributes.get('last_energy_reading'))
             self._cumulative_energy_kwh = float(last_state.attributes.get('cumulative_energy_kwh'))
         self.async_write_ha_state()
         async_track_state_change_event(self.hass, self._energy_sensor_id, self._async_update_energy_price_event)


### PR DESCRIPTION
Fixes the following errors, so dynamic energy cost is no longer broken at startup:

`2024-05-26 08:39:24.350 ERROR (MainThread) [homeassistant.components.sensor] Error adding entity sensor.washing_machine_switch_0_daily_energy_cost for domain sensor with platform dynamic_energy_cost
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 892, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1358, in add_to_platform_finish
    await self.async_added_to_hass()
  File "/config/custom_components/dynamic_energy_cost/energy_based_sensors.py", line 118, in async_added_to_hass
    self._last_energy_reading = float(last_state.attributes.get('last_energy'))`