### PR TITLE
Support for negative prices and energy delivery

### DIFF
--- a/custom_components/dynamic_energy_cost/config_flow.py
+++ b/custom_components/dynamic_energy_cost/config_flow.py
@@ -8,8 +8,10 @@ from .const import DOMAIN, ELECTRICITY_PRICE_SENSOR, POWER_SENSOR, ENERGY_SENSOR
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class DynamicEnergyCostConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Dynamic Energy Cost."""
+
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
@@ -27,38 +29,51 @@ class DynamicEnergyCostConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     cv.entity_id(user_input["power_sensor"])
                 if user_input.get("energy_sensor"):
                     cv.entity_id(user_input["energy_sensor"])
-                
+
                 # Check that either power sensor or energy sensor is filled
-                if not user_input.get("power_sensor") and not user_input.get("energy_sensor"):
+                if not user_input.get("power_sensor") and not user_input.get(
+                    "energy_sensor"
+                ):
                     _LOGGER.warning("Neither power nor energy sensor was provided.")
-                    raise exceptions.Invalid("Please enter either a power sensor or an energy sensor, not both.")
+                    raise exceptions.Invalid(
+                        "Please enter either a power sensor or an energy sensor, not both."
+                    )
                 if user_input.get("power_sensor") and user_input.get("energy_sensor"):
                     _LOGGER.warning("Both power and energy sensors were provided.")
-                    raise exceptions.Invalid("Please enter only one type of sensor (power or energy).")
+                    raise exceptions.Invalid(
+                        "Please enter only one type of sensor (power or energy)."
+                    )
 
                 # Create the config dictionary
                 config = {
                     "electricity_price_sensor": user_input["electricity_price_sensor"],
                     "power_sensor": user_input.get("power_sensor"),
-                    "energy_sensor": user_input.get("energy_sensor")
+                    "energy_sensor": user_input.get("energy_sensor"),
                 }
                 _LOGGER.info("Config entry created successfully.")
                 return self.async_create_entry(title="Dynamic Energy Cost", data=config)
+
             except vol.Invalid as err:
                 _LOGGER.error("Validation error: %s", err)
                 errors["base"] = "invalid_entity"
 
-        schema = vol.Schema({
-            vol.Required("electricity_price_sensor"): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="sensor", multiple=False)
-            ),
-            vol.Optional("power_sensor"): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="sensor", multiple=False, device_class="power")
-            ),
-            vol.Optional("energy_sensor"): selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="sensor", multiple=False, device_class="energy")
-            )
-        })
+        schema = vol.Schema(
+            {
+                vol.Required("electricity_price_sensor"): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="sensor", multiple=False)
+                ),
+                vol.Optional("power_sensor"): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain="sensor", multiple=False, device_class="power"
+                    )
+                ),
+                vol.Optional("energy_sensor"): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain="sensor", multiple=False, device_class="energy"
+                    )
+                ),
+            }
+        )
 
         return self.async_show_form(
             step_id="user",
@@ -68,5 +83,63 @@ class DynamicEnergyCostConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "electricity_price_sensor": "Electricity Price Sensor",
                 "power_sensor": "Power Usage Sensor",
                 "energy_sensor": "Energy (kWh) Sensor",
+            },
+        )
+
+    # newly added !!
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return DynamicEnergyCostOptionsFlow(config_entry)
+
+
+# newly added !!
+class DynamicEnergyCostOptionsFlow(config_entries.OptionsFlow):
+    """Handle an options flow for DynamicEnergyCost."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        return await self.async_step_user(user_input)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+
+        # Get the current values from the config entry
+        current_values = self.config_entry.data
+
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    "electricity_price_sensor",
+                    default=current_values.get("electricity_price_sensor"),
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="sensor", multiple=False)
+                ),
+                vol.Optional(
+                    "power_sensor", default=current_values.get("power_sensor")
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain="sensor", multiple=False, device_class="power"
+                    )
+                ),
+                vol.Optional(
+                    "energy_sensor", default=current_values.get("energy_sensor")
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain="sensor", multiple=False, device_class="energy"
+                    )
+                ),
             }
+        )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=schema,
+            errors=errors,
         )

--- a/custom_components/dynamic_energy_cost/energy_based_sensors.py
+++ b/custom_components/dynamic_energy_cost/energy_based_sensors.py
@@ -1,14 +1,22 @@
 import logging
 from datetime import timedelta
 from homeassistant.util.dt import now
-from homeassistant.helpers.event import async_track_state_change_event, async_track_point_in_time
-from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
+from homeassistant.helpers.event import (
+    async_track_state_change_event,
+    async_track_point_in_time,
+)
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorDeviceClass,
+    SensorStateClass,
+)
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.core import callback
 from .const import DOMAIN, ELECTRICITY_PRICE_SENSOR, ENERGY_SENSOR, SERVICE_RESET_COST
 
 _LOGGER = logging.getLogger(__name__)
+
 
 class BaseEnergyCostSensor(RestoreEntity, SensorEntity):
     """Base sensor for handling energy cost data."""
@@ -18,34 +26,48 @@ class BaseEnergyCostSensor(RestoreEntity, SensorEntity):
         self.hass = hass
         self._energy_sensor_id = energy_sensor_id
         self._price_sensor_id = price_sensor_id
-        self._state = 0 	                # intermediate energy costs
-        self._unit_of_measurement = 'EUR'   # Default to EUR, will update after entity addition
+        self._state = 0  # intermediate energy costs
+        self._unit_of_measurement = (
+            "EUR"  # Default to EUR, will update after entity addition
+        )
         self._interval = interval
-        self._last_energy_reading = None    # updated on first energy change and any price change events
+        self._last_energy_reading = (
+            None  # updated on first energy change and any price change events
+        )
         self._cumulative_energy = 0
-        self._cumulative_cost = 0           # updated on price change events and used for more precise cost calculations
+        self._cumulative_cost = 0  # updated on price change events and used for more precise cost calculations
         self._last_reset_time = now()
         self.schedule_next_reset()
-        _LOGGER.debug("Sensor initialized with energy sensor ID %s and price sensor ID %s.", energy_sensor_id, price_sensor_id)
+        _LOGGER.debug(
+            "Sensor initialized with energy sensor ID %s and price sensor ID %s.",
+            energy_sensor_id,
+            price_sensor_id,
+        )
 
-        _LOGGER.debug(f"Initializing EnergyCostSensor with energy_sensor_id: {energy_sensor_id} and price_sensor_id: {price_sensor_id}")
+        _LOGGER.debug(
+            f"Initializing EnergyCostSensor with energy_sensor_id: {energy_sensor_id} and price_sensor_id: {price_sensor_id}"
+        )
 
         # Generate friendly names based on the energy sensor's ID
-        base_part = energy_sensor_id.split('.')[-1]
+        base_part = energy_sensor_id.split(".")[-1]
         _LOGGER.debug(f"Base part extracted from energy_sensor_id: {base_part}")
 
-        friendly_name_parts = base_part.replace('_', ' ').split()
-        _LOGGER.debug(f"Parts after replacing underscores and splitting: {friendly_name_parts}")
+        friendly_name_parts = base_part.replace("_", " ").split()
+        _LOGGER.debug(
+            f"Parts after replacing underscores and splitting: {friendly_name_parts}"
+        )
 
         # Exclude words that are commonly not part of the main identifier
-        friendly_name_parts = [word for word in friendly_name_parts if word.lower() != 'energy']
+        friendly_name_parts = [
+            word for word in friendly_name_parts if word.lower() != "energy"
+        ]
         _LOGGER.debug(f"Parts after removing 'energy': {friendly_name_parts}")
 
-        friendly_name = ' '.join(friendly_name_parts).title()
+        friendly_name = " ".join(friendly_name_parts).title()
         _LOGGER.debug(f"Final friendly name generated: {friendly_name}")
 
         self._base_name = friendly_name
-        self._device_name = friendly_name + ' Dynamic Energy Cost'
+        self._device_name = friendly_name + " Dynamic Energy Cost"
 
         _LOGGER.debug(f"Sensor base name set to: {self._base_name}")
         _LOGGER.debug(f"Sensor device name set to: {self._device_name}")
@@ -66,13 +88,14 @@ class BaseEnergyCostSensor(RestoreEntity, SensorEntity):
     @property
     def name(self):
         return f"{self._base_name} {self._interval.capitalize()} Energy Cost"
+
     @property
     def device_info(self):
         """Return device information to link this sensor with the integration."""
         return {
             "identifiers": {(DOMAIN, self._energy_sensor_id)},
             "name": self._device_name,
-            "manufacturer": "Custom Integration"
+            "manufacturer": "Custom Integration",
         }
 
     @property
@@ -102,56 +125,87 @@ class BaseEnergyCostSensor(RestoreEntity, SensorEntity):
     def extra_state_attributes(self):
         """Return the state attributes of the device."""
         attrs = super().extra_state_attributes or {}  # Ensure it's a dict
-        attrs['cumulative_energy'] = self._cumulative_energy
-        attrs['last_energy_reading'] = self._last_energy_reading
-        attrs['cumulative_cost'] = self._cumulative_cost
+        attrs["cumulative_energy"] = self._cumulative_energy
+        attrs["last_energy_reading"] = self._last_energy_reading
+        attrs["cumulative_cost"] = self._cumulative_cost
         if self._cumulative_energy > 0:
-            attrs['average_energy_cost'] = self._cumulative_cost / self._cumulative_energy
+            attrs["average_energy_cost"] = (
+                self._cumulative_cost / self._cumulative_energy
+            )
         return attrs
-    
+
     # -----------------------------------------------------------------------------------------------
     async def async_added_to_hass(self):
         """Load the last known state and subscribe to updates."""
         await super().async_added_to_hass()
         self._unit_of_measurement = self.get_currency()
         last_state = await self.async_get_last_state()
-        if last_state and last_state.state not in ['unknown', 'unavailable', None]:
+        if last_state and last_state.state not in ["unknown", "unavailable", None]:
             self._state = float(last_state.state)
-            self._last_energy_reading = float(last_state.attributes.get('last_energy_reading'))
-            if last_state.attributes.get('cumulative_energy') is not None:
-                self._cumulative_energy = float(last_state.attributes.get('cumulative_energy'))
-            if last_state.attributes.get('cumulative_cost') is not None:
-                self._cumulative_cost = float(last_state.attributes.get('cumulative_cost'))
+            if last_state.attributes.get("last_energy_reading") is not None:
+                self._last_energy_reading = float(
+                    last_state.attributes.get("last_energy_reading")
+                )
+            if last_state.attributes.get("cumulative_energy") is not None:
+                self._cumulative_energy = float(
+                    last_state.attributes.get("cumulative_energy")
+                )
+            if last_state.attributes.get("cumulative_cost") is not None:
+                self._cumulative_cost = float(
+                    last_state.attributes.get("cumulative_cost")
+                )
         self.async_write_ha_state()
-        async_track_state_change_event(self.hass, self._energy_sensor_id, self._async_update_energy_event)
-        async_track_state_change_event(self.hass, self._price_sensor_id, self._async_update_price_event)
+        async_track_state_change_event(
+            self.hass, self._energy_sensor_id, self._async_update_energy_event
+        )
+        async_track_state_change_event(
+            self.hass, self._price_sensor_id, self._async_update_price_event
+        )
         self.schedule_next_reset()
 
     # -----------------------------------------------------------------------------------------------
     def get_currency(self):
         """Extract the currency from the unit of measurement of the price sensor."""
         price_entity = self.hass.states.get(self._price_sensor_id)
-        if price_entity and price_entity.attributes.get('unit_of_measurement'):
-            currency = price_entity.attributes['unit_of_measurement'].split('/')[0].strip()
-            if (currency == '€'):
-                currency = 'EUR'
-            _LOGGER.debug(f"Extracted currency '{currency}' from unit of measurement '{price_entity.attributes['unit_of_measurement']}'.")
+        if price_entity and price_entity.attributes.get("unit_of_measurement"):
+            currency = (
+                price_entity.attributes["unit_of_measurement"].split("/")[0].strip()
+            )
+            if currency == "€":
+                currency = "EUR"
+            _LOGGER.debug(
+                f"Extracted currency '{currency}' from unit of measurement '{price_entity.attributes['unit_of_measurement']}'."
+            )
             return currency
         else:
-            _LOGGER.warning(f"Unit of measurement not available or invalid for sensor {self._price_sensor_id}, defaulting to 'EUR'.")
-        return 'EUR'  # Default to EUR if not found
+            _LOGGER.warning(
+                f"Unit of measurement not available or invalid for sensor {self._price_sensor_id}, defaulting to 'EUR'."
+            )
+        return "EUR"  # Default to EUR if not found
 
     # -----------------------------------------------------------------------------------------------
     # determine the next reset time
     def calculate_next_reset_time(self):
         current_time = now()
         if self._interval == "daily":
-            next_reset = current_time.replace(hour=0, minute=0, second=1, microsecond=0) + timedelta(days=1)
+            next_reset = current_time.replace(
+                hour=0, minute=0, second=1, microsecond=0
+            ) + timedelta(days=1)
         elif self._interval == "monthly":
-            next_month = (current_time.replace(day=1) + timedelta(days=32)).replace(day=1)
+            next_month = (current_time.replace(day=1) + timedelta(days=32)).replace(
+                day=1
+            )
             next_reset = next_month.replace(hour=0, minute=0, second=1, microsecond=0)
         elif self._interval == "yearly":
-            next_reset = current_time.replace(year=current_time.year + 1, month=1, day=1, hour=0, minute=0, second=1, microsecond=0)
+            next_reset = current_time.replace(
+                year=current_time.year + 1,
+                month=1,
+                day=1,
+                hour=0,
+                minute=0,
+                second=1,
+                microsecond=0,
+            )
         return next_reset
 
     # schedule a reset
@@ -163,24 +217,33 @@ class BaseEnergyCostSensor(RestoreEntity, SensorEntity):
     async def _reset_meter(self, _):
         self._state = 0  # Reset the cost to zero
         self._cumulative_cost = 0
-        self._cumulative_energy = 0 # Reset the cumulative energy kWh count to zero
+        self._cumulative_energy = 0  # Reset the cumulative energy kWh count to zero
         self._last_energy_reading = None
-        self.async_write_ha_state() # Update the state in Home Assistant
-        self.schedule_next_reset() # Reschedule the next reset
-        _LOGGER.debug(f"Meter reset for {self.name} and cumulative energy reset to {self._cumulative_energy}. Next reset scheduled.")
+        self.async_write_ha_state()  # Update the state in Home Assistant
+        self.schedule_next_reset()  # Reschedule the next reset
+        _LOGGER.debug(
+            f"Meter reset for {self.name} and cumulative energy reset to {self._cumulative_energy}. Next reset scheduled."
+        )
 
     # -----------------------------------------------------------------------------------------------
     # when there is a price change we need to calculate the consumed energy used since last reading for the old price
     async def _async_update_price_event(self, event):
         """Handle price sensor state changes."""
-        old_price_state = event.data.get('old_state')
-        energy_state = self.hass.states.get(self._energy_sensor_id) #current energy readings
-
-        if not energy_state or not old_price_state or energy_state.state in ['unknown', 'unavailable'] or old_price_state.state in ['unknown', 'unavailable']:
-            _LOGGER.warning("One or more sensors are unavailable. Skipping update.")
-            return
-        
         try:
+            old_price_state = event.data.get("old_state")
+            energy_state = self.hass.states.get(
+                self._energy_sensor_id
+            )  # current energy readings
+
+            if (
+                not energy_state
+                or not old_price_state
+                or energy_state.state in ["unknown", "unavailable"]
+                or old_price_state.state in ["unknown", "unavailable"]
+            ):
+                _LOGGER.debug("One or more sensors are unavailable. Skipping update.")
+                return
+
             current_energy = float(energy_state.state)
             price = float(old_price_state.state)
 
@@ -188,63 +251,90 @@ class BaseEnergyCostSensor(RestoreEntity, SensorEntity):
                 energy_difference = current_energy - self._last_energy_reading
                 cost_increment = energy_difference * price
                 self._cumulative_cost += cost_increment
-                _LOGGER.info(f"Energy cost synchronized from {self._state} EUR to {self._cumulative_cost} EUR")
                 self._state = self._cumulative_cost
-                self._cumulative_energy += energy_difference  # Add to the running total of energy
+                self._cumulative_energy += (
+                    energy_difference  # Add to the running total of energy
+                )
+                _LOGGER.info(
+                    f"Change in Energy price: cumulative cost {self._cumulative_cost} EUR and cumulative energy usage to {self._cumulative_energy} kWh"
+                )
 
             else:
-                _LOGGER.debug("No previous energy reading available; initializing with current reading.")
+                _LOGGER.debug(
+                    "No previous energy reading available; initializing with current reading."
+                )
 
             self._last_energy_reading = current_energy  # Always update the last reading
             self.async_write_ha_state()
 
         except Exception as e:
-            _LOGGER.error(f"Failed to update energy costs due to an error: {e}", exc_info=True)
+            _LOGGER.error(
+                f"Failed to update energy costs due to an error: {e}", exc_info=True
+            )
         pass
 
     # -----------------------------------------------------------------------------------------------
     async def _async_update_energy_event(self, event):
         """Handle energy sensor state changes."""
         """Update the energy costs using the latest sensor states, adding both incremental as decremental costs."""
-        energy_state = event.data.get('new_state')
-        price_state = self.hass.states.get(self._price_sensor_id)
-
-        if not energy_state or not price_state or energy_state.state in ['unknown', 'unavailable'] or price_state.state in ['unknown', 'unavailable']:
-            _LOGGER.warning("One or more sensors are unavailable. Skipping update.")
-            return
-
-        if self._last_energy_reading is None:
-            _LOGGER.debug("No previous energy reading available; initializing with current reading.")
-            self._last_energy_reading = current_energy  # Initialize with current reading
-            return
-
         try:
+            energy_state = event.data.get("new_state")
+            price_state = self.hass.states.get(self._price_sensor_id)
+
+            if (
+                not energy_state
+                or not price_state
+                or energy_state.state in ["unknown", "unavailable"]
+                or price_state.state in ["unknown", "unavailable"]
+            ):
+                _LOGGER.debug("One or more sensors are unavailable. Skipping update.")
+                return
+
             current_energy = float(energy_state.state)
             price = float(price_state.state)
 
+            if self._last_energy_reading is None:
+                _LOGGER.debug(
+                    "No previous energy reading available; initializing with current reading."
+                )
+                self._last_energy_reading = (
+                    current_energy  # Initialize with current reading
+                )
+                return
+
             energy_difference = current_energy - self._last_energy_reading
             cost_increment = energy_difference * price
-            self._state = self._cumulative_cost + cost_increment        # set state to the cumulative cost + increment since last energy reading
-            _LOGGER.info(f"Energy cost incremented by {cost_increment} EUR, total cost now {self._state} EUR")
-                
+            self._state = (
+                self._cumulative_cost + cost_increment
+            )  # set state to the cumulative cost + increment since last energy reading
+            _LOGGER.info(
+                f"Energy cost incremented by {cost_increment} on top of {self._cumulative_cost}, total cost now {self._state} EUR"
+            )
+
             self.async_write_ha_state()
 
         except Exception as e:
-            _LOGGER.error(f"Failed to update energy costs due to an error: {e}", exc_info=True)
+            _LOGGER.error(
+                f"Failed to update energy costs due to an error: {e}", exc_info=True
+            )
         pass
+
 
 # Define sensor classes for each interval
 class DailyEnergyCostSensor(BaseEnergyCostSensor):
     def __init__(self, hass, energy_sensor_id, price_sensor_id):
         super().__init__(hass, energy_sensor_id, price_sensor_id, "daily")
 
+
 class MonthlyEnergyCostSensor(BaseEnergyCostSensor):
     def __init__(self, hass, energy_sensor_id, price_sensor_id):
         super().__init__(hass, energy_sensor_id, price_sensor_id, "monthly")
 
+
 class YearlyEnergyCostSensor(BaseEnergyCostSensor):
     def __init__(self, hass, energy_sensor_id, price_sensor_id):
         super().__init__(hass, energy_sensor_id, price_sensor_id, "yearly")
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     energy_sensor_id = config_entry.data.get(ENERGY_SENSOR)
@@ -252,6 +342,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     sensors = [
         DailyEnergyCostSensor(hass, energy_sensor_id, price_sensor_id),
         MonthlyEnergyCostSensor(hass, energy_sensor_id, price_sensor_id),
-        YearlyEnergyCostSensor(hass, energy_sensor_id, price_sensor_id)
+        YearlyEnergyCostSensor(hass, energy_sensor_id, price_sensor_id),
     ]
     async_add_entities(sensors, True)

--- a/custom_components/dynamic_energy_cost/energy_based_sensors.py
+++ b/custom_components/dynamic_energy_cost/energy_based_sensors.py
@@ -21,10 +21,10 @@ class BaseEnergyCostSensor(RestoreEntity, SensorEntity):
         self._state = 0
         self._unit_of_measurement = 'EUR'  # Default to EUR, will update after entity addition
         self._interval = interval
-        self._last_energy_reading = None
+        self._last_energy_reading = None        # updated on each energy change
         self._cumulative_energy_kwh = 0
-        self._calibrated_energy_reading = None
-        self._calibrated_state = 0
+        self._calibrated_energy_reading = None  # updated on last price change event
+        self._calibrated_state = 0              # updated on price changed event and used for more precise cost calculations
         self._last_reset_time = now()
         self.schedule_next_reset()
         _LOGGER.debug("Sensor initialized with energy sensor ID %s and price sensor ID %s.", energy_sensor_id, price_sensor_id)
@@ -106,7 +106,6 @@ class BaseEnergyCostSensor(RestoreEntity, SensorEntity):
         attrs['cumulative_energy_kwh'] = self._cumulative_energy_kwh
         attrs['last_energy_reading'] = self._last_energy_reading
         attrs['average_energy_cost'] = self._state / self._cumulative_energy_kwh if self._cumulative_energy_kwh else 0
-        attrs['calibrated_state'] = self._calibrated_state
         return attrs
     
     # -----------------------------------------------------------------------------------------------

--- a/custom_components/dynamic_energy_cost/power_based_sensors.py
+++ b/custom_components/dynamic_energy_cost/power_based_sensors.py
@@ -1,18 +1,36 @@
 import logging
 from decimal import Decimal
-from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorDeviceClass,
+    SensorStateClass,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.core import callback
-from homeassistant.helpers.event import async_track_state_change_event, async_track_time_interval, async_track_point_in_time
+from homeassistant.helpers.event import (
+    async_track_state_change_event,
+    async_track_time_interval,
+    async_track_point_in_time,
+)
 from homeassistant.util.dt import now
 from datetime import timedelta
-from .const import DOMAIN, ELECTRICITY_PRICE_SENSOR, ENERGY_SENSOR, POWER_SENSOR, SERVICE_RESET_COST
+from .const import (
+    DOMAIN,
+    ELECTRICITY_PRICE_SENSOR,
+    ENERGY_SENSOR,
+    POWER_SENSOR,
+    SERVICE_RESET_COST,
+)
+
 _LOGGER = logging.getLogger(__name__)
+
 
 class RealTimeCostSensor(SensorEntity):
     """Sensor that calculates energy cost in real-time based on power usage and electricity price."""
 
-    def __init__(self, hass, config_entry, electricity_price_sensor_id, power_sensor_id, name):
+    def __init__(
+        self, hass, config_entry, electricity_price_sensor_id, power_sensor_id, name
+    ):
         """Initialize the sensor."""
         self.hass = hass
         self._config_entry = config_entry
@@ -20,17 +38,23 @@ class RealTimeCostSensor(SensorEntity):
         self._power_sensor_id = power_sensor_id
         self._state = Decimal(0)
 
-        _LOGGER.debug(f"Initialized Real Time Cost Sensor with price sensor: {electricity_price_sensor_id} and power sensor: {power_sensor_id}")
+        _LOGGER.debug(
+            f"Initialized Real Time Cost Sensor with price sensor: {electricity_price_sensor_id} and power sensor: {power_sensor_id}"
+        )
 
         # Extract a friendly name from the power sensor's entity ID
-        base_part = power_sensor_id.split('.')[-1]  # Assuming entity_id format like 'sensor.heat_pump_power'
-        friendly_name_parts = base_part.replace('_', ' ').split()  # Split into words
-        friendly_name_parts = [word for word in friendly_name_parts if word.lower() != 'power']  # Remove the word "Power"
-        friendly_name = ' '.join(friendly_name_parts).title()  # Rejoin and title-case
-        self._base_name = friendly_name + ' Real Time Energy Cost'
+        base_part = power_sensor_id.split(".")[
+            -1
+        ]  # Assuming entity_id format like 'sensor.heat_pump_power'
+        friendly_name_parts = base_part.replace("_", " ").split()  # Split into words
+        friendly_name_parts = [
+            word for word in friendly_name_parts if word.lower() != "power"
+        ]  # Remove the word "Power"
+        friendly_name = " ".join(friendly_name_parts).title()  # Rejoin and title-case
+        self._base_name = friendly_name + " Real Time Energy Cost"
 
         # Prepare a device name using the friendly base part
-        self._device_name = friendly_name + ' Dynamic Energy Cost'
+        self._device_name = friendly_name + " Dynamic Energy Cost"
 
     @property
     def unique_id(self):
@@ -43,7 +67,7 @@ class RealTimeCostSensor(SensorEntity):
         return {
             "identifiers": {(DOMAIN, self._config_entry.entry_id)},
             "name": self._device_name,
-            "manufacturer": "Custom Integration"
+            "manufacturer": "Custom Integration",
         }
 
     @property
@@ -59,24 +83,32 @@ class RealTimeCostSensor(SensorEntity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return 'EUR/h'
-
+        return "EUR/h"
 
     @callback
     def handle_state_change(self, event):
         """Handle changes to the electricity price or power usage."""
-        entity_id = event.data['entity_id']
-        new_state = event.data.get('new_state')
+        entity_id = event.data["entity_id"]
+        new_state = event.data.get("new_state")
 
-        if new_state is None or new_state.state in ['unknown', 'unavailable']:
-            _LOGGER.warning(f"State of {entity_id} is '{new_state.state}', skipping update.")
+        if new_state is None or new_state.state in ["unknown", "unavailable"]:
+            _LOGGER.info(
+                f"State of {entity_id} is '{new_state.state}', skipping update."
+            )
             return
 
-        electricity_price = self.hass.states.get(self._electricity_price_sensor_id).state
+        electricity_price = self.hass.states.get(
+            self._electricity_price_sensor_id
+        ).state
         power_usage = self.hass.states.get(self._power_sensor_id).state
 
-        if not electricity_price or not power_usage or electricity_price in ['unknown', 'unavailable'] or power_usage in ['unknown', 'unavailable']:
-            _LOGGER.warning("One or more sensor values are unavailable, skipping update.")
+        if (
+            not electricity_price
+            or not power_usage
+            or electricity_price in ["unknown", "unavailable"]
+            or power_usage in ["unknown", "unavailable"]
+        ):
+            _LOGGER.info("One or more sensor values are unavailable, skipping update.")
             return
 
         try:
@@ -93,21 +125,36 @@ class RealTimeCostSensor(SensorEntity):
     async def async_added_to_hass(self):
         """Register callbacks when added to hass."""
         async_track_state_change_event(
-            self.hass, [self._electricity_price_sensor_id, self._power_sensor_id], self.handle_state_change
+            self.hass,
+            [self._electricity_price_sensor_id, self._power_sensor_id],
+            self.handle_state_change,
         )
-        _LOGGER.info(f"Callbacks registered for {self._electricity_price_sensor_id} and {self._power_sensor_id}")
+        _LOGGER.info(
+            f"Callbacks registered for {self._electricity_price_sensor_id} and {self._power_sensor_id}"
+        )
+
 
 def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the sensor platform from a config entry."""
-    electricity_price_sensor = config_entry.data.get('electricity_price_sensor')
-    power_sensor = config_entry.data.get('power_sensor')
-    real_time_cost_sensor = RealTimeCostSensor(hass, config_entry, electricity_price_sensor, power_sensor, 'Real Time Energy Cost')
+    electricity_price_sensor = config_entry.data.get("electricity_price_sensor")
+    power_sensor = config_entry.data.get("power_sensor")
+    real_time_cost_sensor = RealTimeCostSensor(
+        hass,
+        config_entry,
+        electricity_price_sensor,
+        power_sensor,
+        "Real Time Energy Cost",
+    )
     async_add_entities([real_time_cost_sensor])
 
     # Utility Meter Sensors setup
-    intervals = ['daily', 'monthly', 'yearly']
-    utility_sensors = [UtilityMeterSensor(hass, real_time_cost_sensor, interval) for interval in intervals]
+    intervals = ["daily", "monthly", "yearly"]
+    utility_sensors = [
+        UtilityMeterSensor(hass, real_time_cost_sensor, interval)
+        for interval in intervals
+    ]
     async_add_entities(utility_sensors)
+
 
 class UtilityMeterSensor(SensorEntity, RestoreEntity):
     """Sensor that calculates cumulative energy costs over set intervals and resets accordingly."""
@@ -118,9 +165,11 @@ class UtilityMeterSensor(SensorEntity, RestoreEntity):
         self.hass = hass
         self._real_time_cost_sensor = real_time_cost_sensor
         self._interval = interval
-        self._state = Decimal('0.00')
+        self._state = Decimal("0.00")
         self._last_update = now()
-        base_name = real_time_cost_sensor.name.replace(" Real Time Energy Cost", "").strip()
+        base_name = real_time_cost_sensor.name.replace(
+            " Real Time Energy Cost", ""
+        ).strip()
         self._name = f"{base_name} {interval.title()} Energy Cost"
 
     async def async_added_to_hass(self):
@@ -128,15 +177,24 @@ class UtilityMeterSensor(SensorEntity, RestoreEntity):
         await super().async_added_to_hass()
         # Restore state if available
         last_state = await self.async_get_last_state()
-        if last_state and last_state.state not in ('unknown', 'unavailable'):
+        if last_state and last_state.state not in ("unknown", "unavailable"):
             try:
                 self._state = Decimal(last_state.state)
             except InvalidOperation:
-                _LOGGER.error("Invalid state value for restoration: %s", last_state.state)
+                _LOGGER.error(
+                    "Invalid state value for restoration: %s", last_state.state
+                )
         self.schedule_next_reset()
-        _LOGGER.debug("Registering state change event for: %s", self._real_time_cost_sensor.entity_id)
+        _LOGGER.debug(
+            "Registering state change event for: %s",
+            self._real_time_cost_sensor.entity_id,
+        )
         try:
-            async_track_state_change_event(self.hass, [self._real_time_cost_sensor.entity_id], self._handle_real_time_cost_update)
+            async_track_state_change_event(
+                self.hass,
+                [self._real_time_cost_sensor.entity_id],
+                self._handle_real_time_cost_update,
+            )
         except Exception as e:
             _LOGGER.error("Failed to track state change: %s", str(e))
 
@@ -144,14 +202,28 @@ class UtilityMeterSensor(SensorEntity, RestoreEntity):
         """Determine the exact datetime for the next reset based on the interval."""
         current_time = now()
         if self._interval == "daily":
-            next_reset = (current_time + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+            next_reset = (current_time + timedelta(days=1)).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
         elif self._interval == "monthly":
-            next_month = (current_time.replace(day=1) + timedelta(days=32)).replace(day=1)
+            next_month = (current_time.replace(day=1) + timedelta(days=32)).replace(
+                day=1
+            )
             next_reset = next_month.replace(hour=0, minute=0, second=0, microsecond=0)
         elif self._interval == "yearly":
-            next_reset = current_time.replace(year=current_time.year + 1, month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
-        
-        _LOGGER.debug(f"Calculated next reset time for {self._interval} reset: {next_reset}")
+            next_reset = current_time.replace(
+                year=current_time.year + 1,
+                month=1,
+                day=1,
+                hour=0,
+                minute=0,
+                second=0,
+                microsecond=0,
+            )
+
+        _LOGGER.debug(
+            f"Calculated next reset time for {self._interval} reset: {next_reset}"
+        )
         return next_reset
 
     @callback
@@ -167,19 +239,21 @@ class UtilityMeterSensor(SensorEntity, RestoreEntity):
         next_reset_time = self.calculate_next_reset_time()
 
         # Cancel existing scheduled reset if it exists
-        if hasattr(self, '_reset_timer'):
+        if hasattr(self, "_reset_timer"):
             self.hass.async_create_task(self.hass.async_remove_job(self._reset_timer))
 
         # Log the scheduling of the next reset
         _LOGGER.debug(f"Scheduling next reset for {self._name} at {next_reset_time}")
 
         # Schedule the next reset
-        self._reset_timer = async_track_point_in_time(self.hass, self._reset_meter, next_reset_time)
+        self._reset_timer = async_track_point_in_time(
+            self.hass, self._reset_meter, next_reset_time
+        )
         _LOGGER.debug("Next reset scheduled successfully.")
 
     async def _reset_meter(self, _):
         """Reset the meter at the specified interval."""
-        self._state = Decimal('0.00')
+        self._state = Decimal("0.00")
         self._last_update = now()
         self.async_write_ha_state()
         self.schedule_next_reset()
@@ -188,23 +262,31 @@ class UtilityMeterSensor(SensorEntity, RestoreEntity):
     @callback
     def _handle_real_time_cost_update(self, event):
         """Update cumulative cost based on the real-time cost sensor updates."""
-        new_state = event.data.get('new_state')
-        if new_state is None or new_state.state in ('unknown', 'unavailable'):
+        new_state = event.data.get("new_state")
+        if new_state is None or new_state.state in ("unknown", "unavailable"):
             _LOGGER.debug("Skipping update due to unavailable state")
             return
 
         try:
             current_cost = Decimal(new_state.state)
-            _LOGGER.debug(f"Current cost retrieved from state: {current_cost}")  # Log current cost
+            _LOGGER.debug(
+                f"Current cost retrieved from state: {current_cost}"
+            )  # Log current cost
 
             time_difference = now() - self._last_update
-            hours_passed = Decimal(time_difference.total_seconds()) / Decimal(3600)  # Convert time difference to hours as Decimal
-            _LOGGER.debug(f"Time difference calculated as: {time_difference}, which is {hours_passed} hours.")  # Log time difference in hours
+            hours_passed = Decimal(time_difference.total_seconds()) / Decimal(
+                3600
+            )  # Convert time difference to hours as Decimal
+            _LOGGER.debug(
+                f"Time difference calculated as: {time_difference}, which is {hours_passed} hours."
+            )  # Log time difference in hours
 
-            self._state += (current_cost * hours_passed).quantize(Decimal('0.01'))
+            self._state += (current_cost * hours_passed).quantize(Decimal("0.01"))
             self._last_update = now()
             self.async_write_ha_state()
-            _LOGGER.debug(f"Updated state to: {self._state} using cost: {current_cost} over {hours_passed} hours")
+            _LOGGER.debug(
+                f"Updated state to: {self._state} using cost: {current_cost} over {hours_passed} hours"
+            )
         except (InvalidOperation, TypeError) as e:
             _LOGGER.error(f"Error updating cumulative cost: {e}")
 
@@ -231,7 +313,7 @@ class UtilityMeterSensor(SensorEntity, RestoreEntity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return 'EUR'
+        return "EUR"
 
     @property
     def device_class(self):

--- a/custom_components/dynamic_energy_cost/power_based_sensors.py
+++ b/custom_components/dynamic_energy_cost/power_based_sensors.py
@@ -197,10 +197,6 @@ class UtilityMeterSensor(SensorEntity, RestoreEntity):
             current_cost = Decimal(new_state.state)
             _LOGGER.debug(f"Current cost retrieved from state: {current_cost}")  # Log current cost
 
-            if current_cost <= 0:  # Skip updates if the new cost is not positive
-                _LOGGER.debug(f"Skipping update as the calculated cost {current_cost} is not positive.")
-                return
-
             time_difference = now() - self._last_update
             hours_passed = Decimal(time_difference.total_seconds()) / Decimal(3600)  # Convert time difference to hours as Decimal
             _LOGGER.debug(f"Time difference calculated as: {time_difference}, which is {hours_passed} hours.")  # Log time difference in hours


### PR DESCRIPTION
I've added support for negative dynamic prices and decreasing energy usage. The latter is usefull for not only net P1 readings, but also for energy readings from home-batteries.

Additionally added a recalculation on each price change event (each hour), overwriting (and correcting) small roundings issues which occur in the normal loop triggered on each energy reading