### PR TITLE
Added possibility to add desc. to integration

### DIFF
--- a/custom_components/dynamic_energy_cost/config_flow.py
+++ b/custom_components/dynamic_energy_cost/config_flow.py
@@ -54,15 +54,17 @@ class DynamicEnergyCostConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "electricity_price_sensor": user_input["electricity_price_sensor"],
                     "power_sensor": user_input.get("power_sensor"),
                     "energy_sensor": user_input.get("energy_sensor"),
+                    "integration_description": user_input.get("integration_description", "Unnamed"),
                 }
                 _LOGGER.info("Config entry created successfully")
-                return self.async_create_entry(title="Dynamic Energy Cost", data=config)
+                return self.async_create_entry(title=f"Dynamic Energy Cost - {user_input.get('integration_description', 'Unnamed')}", data=config)
             except vol.Invalid as err:
                 _LOGGER.error("Validation error: %s", err)
                 errors["base"] = "invalid_entity"
 
         schema = vol.Schema(
             {
+                vol.Optional("integration_description"): selector.TextSelector(),
                 vol.Required("electricity_price_sensor"): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain="sensor", multiple=False)
                 ),
@@ -84,6 +86,7 @@ class DynamicEnergyCostConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=schema,
             errors=errors,
             description_placeholders={
+                "integration_description": "Name to append the integration title",
                 "electricity_price_sensor": "Electricity Price Sensor",
                 "power_sensor": "Power Usage Sensor",
                 "energy_sensor": "Energy (kWh) Sensor",

--- a/custom_components/dynamic_energy_cost/strings.json
+++ b/custom_components/dynamic_energy_cost/strings.json
@@ -5,6 +5,7 @@
         "title": "Configure your Dynamic Energy Cost Integration",
         "description": "Please provide the entities for your sensors. Ensure that the power sensor measures in Watts (W) and the price sensor reflects the cost in Euro per kilowatt-hour (EUR/kWh).",
         "data": {
+          "integration_description": "Name to append the integration name",
           "electricity_price_sensor": "Electricity Price Sensor Entity (W)",
           "power_sensor": "Power Sensor Entity (eur/kwh)"
         }

--- a/custom_components/dynamic_energy_cost/translations/en.json
+++ b/custom_components/dynamic_energy_cost/translations/en.json
@@ -5,6 +5,7 @@
         "title": "Configure your Dynamic Energy Cost Integration",
         "description": "Select either a power sensor (W) or an energy sensor (kWh), along with the price sensor (EUR/kWh).",
         "data": {
+		  "integration_description": "Name to append the integration title",
           "electricity_price_sensor": "Electricity Price Sensor Entity ID (eur/kWh)",
           "power_sensor": "Power Usage Sensor Entity ID (W) - Optional if energy sensor is provided",
           "energy_sensor": "Energy Usage Sensor Entity ID (kWh) - Optional if power sensor is provided"


### PR DESCRIPTION
### Dynamic Title Generation:

The title of the integration now includes the integration_description provided by the user during setup.
If integration_description is not provided, a default value of "Unnamed" will be used in the title (e.g., "Dynamic Energy Cost - Unnamed").

**Example Output**

1. If the user provides a description, e.g., "My Home":

- Integration title: "Dynamic Energy Cost - My Home"

2. If no description is provided:

- Integration title: "Dynamic Energy Cost - Unnamed"




