### PR TITLE
Calibrate service

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ target:
 
 ## Calibrating the cost sensors
 
-Dynamic Energy Cost provides a service `dynamic_energy_cost.calibrate` which you can call to Change the value of a given sensor. You can call this service from the GUI (Developer tools -> Services) or use this in automations.
+Dynamic Energy Cost provides a service `dynamic_energy_cost.calibrate` which you can call to change the value of a given sensor. You can call this service from the GUI (Developer tools -> Services) or use this in automations.
 
 ```yaml
 service: dynamic_energy_cost.calibrate

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ target:
   entity_id: sensor.your_sensor_entity_id
 ```
 
+## Calibrating the cost sensors
+
+Dynamic Energy Cost provides a service `dynamic_energy_cost.calibrate` which you can call to Change the value of a given sensor. You can call this service from the GUI (Developer tools -> Services) or use this in automations.
+
+```yaml
+service: dynamic_energy_cost.calibrate
+target:
+  entity_id: sensor.your_sensor_entity_id
+  value: 100
+```
+
 ## Prerequisites
 
 - **Electricity Price Sensor:** A sensor that provides the current electricity price in EUR/kWh.

--- a/custom_components/dynamic_energy_cost/const.py
+++ b/custom_components/dynamic_energy_cost/const.py
@@ -5,6 +5,7 @@ ELECTRICITY_PRICE_SENSOR = "electricity_price_sensor"
 POWER_SENSOR = "power_sensor"
 ENERGY_SENSOR = "energy_sensor"
 SERVICE_RESET_COST = "reset_cost"
+SERVICE_CALIBRATE = "calibrate"
 
 HOURLY = "hourly"
 DAILY = "daily"

--- a/custom_components/dynamic_energy_cost/entity.py
+++ b/custom_components/dynamic_energy_cost/entity.py
@@ -117,6 +117,13 @@ class BaseUtilitySensor(SensorEntity):
         self.async_write_ha_state()
         _LOGGER.debug("Meter reset for %s", self._name)
 
+    @callback
+    def async_calibrate(self, value):
+        """Calibrate the state with a given value."""
+        _LOGGER.debug("Calibrate %s = %s type(%s)", self._name, value, type(value))
+        self._state = float(Decimal(str(value)))
+        self.async_write_ha_state()
+
     async def async_will_remove_from_hass(self):
         """Remove the reset event from the schedule."""
         if self.event_unsub:

--- a/custom_components/dynamic_energy_cost/sensor.py
+++ b/custom_components/dynamic_energy_cost/sensor.py
@@ -2,6 +2,7 @@
 
 from decimal import Decimal, InvalidOperation
 import logging
+import voluptuous as vol
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
@@ -10,6 +11,7 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.template import is_number
 from homeassistant.util.dt import now
 
 from .const import (
@@ -22,6 +24,7 @@ from .const import (
     MONTHLY,
     POWER_SENSOR,
     SERVICE_RESET_COST,
+    SERVICE_CALIBRATE,
     WEEKLY,
     YEARLY,
 )
@@ -31,6 +34,11 @@ INTERVALS = [HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY, MANUAL]
 
 _LOGGER = logging.getLogger(__name__)
 
+def validate_is_number(value):
+    """Validate value is a number."""
+    if is_number(value):
+        return value
+    raise vol.Invalid("Value is not a number")
 
 async def register_entity_services():
     """Register custom services for energy cost sensors."""
@@ -40,6 +48,12 @@ async def register_entity_services():
         SERVICE_RESET_COST,
         {},  # No parameters for the service
         "async_reset",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_CALIBRATE,
+        {vol.Required("value"): validate_is_number},
+        "async_calibrate",
     )
 
 

--- a/custom_components/dynamic_energy_cost/services.yaml
+++ b/custom_components/dynamic_energy_cost/services.yaml
@@ -2,3 +2,14 @@ reset_cost:
   target:
     entity:
       domain: sensor
+calibrate:
+  target:
+    entity:
+      domain: sensor
+      integration: utility_meter
+  fields:
+    value:
+      example: "100"
+      required: true
+      selector:
+        text:


### PR DESCRIPTION
- Add a `calibrate` service, inspired by Home Assistant's [utility_meter.calibrate](https://www.home-assistant.io/integrations/utility_meter/#action-utility_metercalibrate)

I was adding and using this calibrate action, after a source energy sensor was reporting wrong data and I wanted to fix my energy cost sensor states.

Steps I performed to fix my wrong states and statistics:
- Calibrate my dynamic energy cost sensors with this new action
- Fix `states` table in the database (I will publish my custom integration that I created for this soon)
- Use _Developer Tools_ -> _Statistics_ -> _Adjust a statistic_ to fix the statistics sum
- Fix `statistics` and `statistics_short_term` tables in the database by writing the value of column `sum` to `state`

The `calibrate` service was crucial for me, to be able to fix all of my sensors, and I hope it can help others, too.