### PR TITLE
Calibrate cumulative cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ target:
 
 ## Calibrating the cost sensors
 
-Dynamic Energy Cost provides a service `dynamic_energy_cost.calibrate` which you can call to change the value of a given sensor. You can call this service from the GUI (Developer tools -> Services) or use this in automations.
+Dynamic Energy Cost provides a service `dynamic_energy_cost.calibrate` which you can call to change the value of a given sensor. You can call this service from the GUI (Developer tools -> Actions) or use this in automations.
 
 ```yaml
-service: dynamic_energy_cost.calibrate
+action: dynamic_energy_cost.calibrate
 target:
   entity_id: sensor.your_sensor_entity_id
-  value: 100
+data:
+  value: "100"
 ```
 
 ## Prerequisites

--- a/custom_components/dynamic_energy_cost/entity.py
+++ b/custom_components/dynamic_energy_cost/entity.py
@@ -122,6 +122,7 @@ class BaseUtilitySensor(SensorEntity):
         """Calibrate the state with a given value."""
         _LOGGER.debug("Calibrate %s = %s type(%s)", self._name, value, type(value))
         self._state = float(Decimal(str(value)))
+        self._cumulative_cost = self._state
         self.async_write_ha_state()
 
     async def async_will_remove_from_hass(self):

--- a/custom_components/dynamic_energy_cost/entity.py
+++ b/custom_components/dynamic_energy_cost/entity.py
@@ -121,8 +121,8 @@ class BaseUtilitySensor(SensorEntity):
     def async_calibrate(self, value):
         """Calibrate the state with a given value."""
         _LOGGER.debug("Calibrate %s = %s type(%s)", self._name, value, type(value))
-        self._state = float(Decimal(str(value)))
-        self._cumulative_cost = self._state
+        self._cumulative_cost = float(str(value))
+        self._state = self._cumulative_cost
         self.async_write_ha_state()
 
     async def async_will_remove_from_hass(self):


### PR DESCRIPTION
- Set `_state` **and** `_cumulative_cost` when using the calibrate action
- Update documentation for using the service

This should fix https://github.com/martinarva/dynamic_energy_cost/issues/89 based on the following findings:

> There was an additional attribute `cumulative_cost` introduced just recently with https://github.com/martinarva/dynamic_energy_cost/pull/79. This wasn't there when I wrote the calibrate service.
> 
> When pulling the latest changes for preparing PR https://github.com/martinarva/dynamic_energy_cost/pull/85, I didn't notice that I will need to consider this new attribute as well. 
