### PR TITLE
Correctly calculate cost after sensor reset

### DIFF
--- a/custom_components/dynamic_energy_cost/sensor.py
+++ b/custom_components/dynamic_energy_cost/sensor.py
@@ -433,13 +433,16 @@ class EnergyCostSensor(RestoreEntity, BaseUtilitySensor):
 
             energy_difference = current_energy - self._last_energy_reading
             cost_increment = energy_difference * price
-            self._state = (
-                self._cumulative_cost + cost_increment
-            )  # set state to the cumulative cost + increment since last energy reading
+            self._cumulative_cost += cost_increment
+            self._state = self._cumulative_cost
+            self._cumulative_energy += (
+                energy_difference  # Add to the running total of energy
+            )
             _LOGGER.info(
                 f"Energy cost incremented by {cost_increment} on top of {self._cumulative_cost}, total cost now {self._state} EUR"
             )
 
+            self._last_energy_reading = current_energy  # Always update the last reading
             self.async_write_ha_state()
 
         except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
This change corrects the first cost calculation, if the trigger is due to energy sensor update, after a sensor have been reset. 

With this change I believe the attribute cumulative_cost can be removed as it is always the same as the state. If you agree, please let me know and I will remove that attribute. 

Believe this corrects the issue reported in #99.