### PR TITLE
Allow number and input number entities for electricity price

### DIFF
--- a/custom_components/dynamic_energy_cost/config_flow.py
+++ b/custom_components/dynamic_energy_cost/config_flow.py
@@ -3,6 +3,9 @@
 import logging
 
 from homeassistant import config_entries
+from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.exceptions import ConfigValidationError
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.data_entry_flow import FlowResult
@@ -94,16 +97,19 @@ class DynamicEnergyCostConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required("integration_description"): selector.TextSelector(),
                 vol.Required("electricity_price_sensor"): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="sensor", multiple=False)
+                    selector.EntitySelectorConfig(
+                        domain=[SENSOR_DOMAIN, NUMBER_DOMAIN, INPUT_NUMBER_DOMAIN],
+                        multiple=False,
+                    )
                 ),
                 vol.Optional("power_sensor"): selector.EntitySelector(
                     selector.EntitySelectorConfig(
-                        domain="sensor", multiple=False, device_class="power"
+                        domain=[SENSOR_DOMAIN], multiple=False, device_class="power"
                     )
                 ),
                 vol.Optional("energy_sensor"): selector.EntitySelector(
                     selector.EntitySelectorConfig(
-                        domain="sensor", multiple=False, device_class="energy"
+                        domain=[SENSOR_DOMAIN], multiple=False, device_class="energy"
                     )
                 ),
             }
@@ -153,20 +159,23 @@ class DynamicEnergyCostOptionsFlow(config_entries.OptionsFlow):
                     "electricity_price_sensor",
                     default=current_values.get("electricity_price_sensor"),
                 ): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="sensor", multiple=False)
+                    selector.EntitySelectorConfig(
+                        domain=[SENSOR_DOMAIN, NUMBER_DOMAIN, INPUT_NUMBER_DOMAIN],
+                        multiple=False,
+                    )
                 ),
                 vol.Optional(
                     "power_sensor", default=current_values.get("power_sensor")
                 ): selector.EntitySelector(
                     selector.EntitySelectorConfig(
-                        domain="sensor", multiple=False, device_class="power"
+                        domain=[SENSOR_DOMAIN], multiple=False, device_class="power"
                     )
                 ),
                 vol.Optional(
                     "energy_sensor", default=current_values.get("energy_sensor")
                 ): selector.EntitySelector(
                     selector.EntitySelectorConfig(
-                        domain="sensor", multiple=False, device_class="energy"
+                        domain=[SENSOR_DOMAIN], multiple=False, device_class="energy"
                     )
                 ),
             }

--- a/custom_components/dynamic_energy_cost/manifest.json
+++ b/custom_components/dynamic_energy_cost/manifest.json
@@ -3,7 +3,7 @@
   "name": "Dynamic Energy Cost",
   "codeowners": ["@martinarva"],
   "config_flow": true,
-  "dependencies": ["sensor"],
+  "dependencies": ["sensor","input_number","number","utility_meter"],
   "documentation": "https://github.com/martinarva/dynamic_energy_cost/",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/martinarva/dynamic_energy_cost/issues/",


### PR DESCRIPTION
**Summary**

I don't have any integration I can use to set my electricity price. Instead, I created an automation that sets the current price on a schedule. It saves the current price to an entity I created.

When setting up the dynamic energy cost integration, I couldn't select my entity as the electricity_price_sensor. This is because the entity is an Input Number entity, and the config flow / option flow schema only allows Sensor entities to be selected.

I updated the schema in my fork to allow Number and Input Number entities to be selected as well. This allowed me to complete setup.

- [x] The pull request points to the `Develop` branch.
- [x] Provided a brief summary of the changes introduced.
- [ ] This pull request fixes issue: I didn't create an issue for this, but I can if you want.
