### PR TITLE
fix: make config_flow work again

### DIFF
--- a/custom_components/dynamic_energy_cost/config_flow.py
+++ b/custom_components/dynamic_energy_cost/config_flow.py
@@ -106,6 +106,7 @@ class DynamicEnergyCostConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return DynamicEnergyCostOptionsFlow(config_entry)
 
+
 class DynamicEnergyCostOptionsFlow(config_entries.OptionsFlow):
     """Handle an options flow for DynamicEnergyCost."""
 
@@ -143,10 +144,7 @@ class DynamicEnergyCostOptionsFlow(config_entries.OptionsFlow):
             ("energy_sensor", "energy"),
         ):
             schema_dict[
-                vol.Optional(
-                    key,
-                    default=current_values.get(key, vol.UNDEFINED)
-                )
+                vol.Optional(key, default=current_values.get(key, vol.UNDEFINED))
             ] = selector.EntitySelector(
                 selector.EntitySelectorConfig(
                     domain=[SENSOR_DOMAIN],


### PR DESCRIPTION
**Summary**

This fixes the config flow triggering an HTTP 500 error. Also applied some DRY optimization while generating the form contents.
I have tested this locally on my HASS 2026.1.0 and it is working fine now. I can edit and create entities without errors.

- [x] The pull request points to the `Develop` branch.
- [x] Provided a brief summary of the changes introduced.
- [x] This pull request fixes issue: https://github.com/martinarva/dynamic_energy_cost/issues/200
