### PR TITLE
Fix config flow during re-configuration

### DIFF
--- a/custom_components/dynamic_energy_cost/config_flow.py
+++ b/custom_components/dynamic_energy_cost/config_flow.py
@@ -128,10 +128,7 @@ class DynamicEnergyCostOptionsFlow(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=user_input)
 
         schema_dict = {
-            vol.Required(
-                "electricity_price_sensor",
-                default=current_values.get("electricity_price_sensor"),
-            ): selector.EntitySelector(
+            vol.Required("electricity_price_sensor"): selector.EntitySelector(
                 selector.EntitySelectorConfig(
                     domain=[SENSOR_DOMAIN, NUMBER_DOMAIN, INPUT_NUMBER_DOMAIN],
                     multiple=False,
@@ -144,7 +141,7 @@ class DynamicEnergyCostOptionsFlow(config_entries.OptionsFlow):
             ("energy_sensor", "energy"),
         ):
             schema_dict[
-                vol.Optional(key, default=current_values.get(key, vol.UNDEFINED))
+                vol.Optional(key)
             ] = selector.EntitySelector(
                 selector.EntitySelectorConfig(
                     domain=[SENSOR_DOMAIN],
@@ -153,8 +150,10 @@ class DynamicEnergyCostOptionsFlow(config_entries.OptionsFlow):
                 )
             )
 
+        data_schema = vol.Schema(schema_dict)
+        data_schema = self.add_suggested_values_to_schema(data_schema, current_values)
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(schema_dict),
+            data_schema=data_schema,
             errors=errors,
         )


### PR DESCRIPTION
**Summary**

Currently when reconfiguring the integration while leaving the Power option empty you will get the error `Entity None is neither a valid entity ID nor a valid UUID`. This is due to the default in the schema being set to `vol.UNDEFINED`. As pointed out [here](https://community.home-assistant.io/t/voluptuous-options-flow-validation-for-an-optional-string-how/305538/4) the defaults should not be used to set the current values, for that the method `add_suggested_values_to_schema` should be called. This PR implementes that. 

This PR might be a bit duplicated with #194, but since that one is still a draft and includes a bit more I submit a new PR for it.

Fixes #203 
